### PR TITLE
add Docker Mihomo config and Microsoft routing

### DIFF
--- a/clash/mihomo.docker.yaml
+++ b/clash/mihomo.docker.yaml
@@ -1,0 +1,355 @@
+# Mihomo for WSL2 + Docker
+# Docker 版源配置：clash/mihomo.sparkle.yaml；更新路由规则时应同步维护两份。
+# 使用前只需要替换：secret 与 proxy-providers 中的 4 个订阅 URL。
+
+port: 7890
+socks-port: 7891
+mixed-port: 7893
+ipv6: false
+allow-lan: true
+bind-address: "*"
+unified-delay: true
+tcp-concurrent: true
+
+# GeoData Settings
+geo-auto-update: true
+geo-update-interval: 48
+geox-url:
+  geoip: "https://cdn.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@release/geoip.dat"
+  geosite: "https://cdn.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@release/geosite.dat"
+  mmdb: "https://cdn.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@release/country.mmdb"
+  asn: "https://github.com/xishang0128/geoip/releases/download/latest/GeoLite2-ASN.mmdb"
+
+# Control Panel
+# Docker 容器内必须监听 0.0.0.0，宿主机暴露范围由 compose.yaml 控制。
+external-controller: "0.0.0.0:9090"
+secret: "CHANGE_ME_TO_A_LONG_RANDOM_SECRET"
+external-ui: ui
+external-ui-url: "https://github.com/MetaCubeX/metacubexd/archive/gh-pages.zip"
+
+# Core Behavior
+# 容器看不到 Windows/其他容器的真实进程，关闭进程识别。
+find-process-mode: off
+keep-alive-idle: 600
+keep-alive-interval: 30
+
+# Profile Settings
+profile:
+  store-selected: true
+  store-fake-ip: true
+
+# Traffic Sniffing
+sniffer:
+  enable: true
+  sniff:
+    HTTP:
+      ports: [80, 8080-8880]
+      override-destination: true
+    TLS:
+      ports: [443, 8443]
+      override-destination: true
+    QUIC:
+      ports: [443, 8443]
+      override-destination: true
+  force-domain:
+    - '+.v2ex.com'
+  skip-domain:
+    - 'Mijia Cloud'
+    - 'dlg.io.mi.com'
+    - '+.push.apple.com'
+    - '+.apple.com'
+
+# 当前 compose 未配置 NET_ADMIN 和 /dev/net/tun；作为 sub2api 的 HTTP 代理无需 TUN。
+tun:
+  enable: false
+
+# DNS Configuration
+dns:
+  enable: true
+  listen: '127.0.0.1:1053'
+  ipv6: false
+  respect-rules: true
+  enhanced-mode: fake-ip
+  fake-ip-range: 198.18.0.0/15
+  fake-ip-filter-mode: blacklist
+  fake-ip-filter:
+    - '+.lan'
+    - '+.local'
+    - geosite:private
+    - geosite:cn
+  default-nameserver:
+    - 223.5.5.5
+    - 119.29.29.29
+  proxy-server-nameserver:
+    - https://dns.alidns.com/dns-query
+    - https://doh.pub/dns-query
+  nameserver:
+    - https://1.1.1.1/dns-query
+    - https://dns.google/dns-query
+  direct-nameserver:
+    - https://dns.alidns.com/dns-query
+    - https://doh.pub/dns-query
+  nameserver-policy:
+    'rule-set:private_domain,cn_domain':
+      - https://dns.alidns.com/dns-query
+      - https://doh.pub/dns-query
+    'geosite:geolocation-!cn':
+      - https://dns.cloudflare.com/dns-query
+      - https://dns.google/dns-query
+
+# 节点订阅与主配置分离。
+# 只替换下面 4 个 URL；不要把真实订阅链接提交到公开仓库。
+# 冷启动时订阅默认直连下载，避免所有节点尚未加载时形成代理循环依赖。
+proxy-providers:
+  helen:
+    type: http
+    url: "https://replace.invalid/helen-subscription"
+    path: ./proxy_providers/helen.yaml
+    interval: 3600
+    health-check:
+      enable: true
+      url: "https://www.gstatic.com/generate_204"
+      interval: 900
+      timeout: 5000
+      lazy: true
+      expected-status: 204
+
+  linux-bkm:
+    type: http
+    url: "https://replace.invalid/linux-bkm-subscription"
+    path: ./proxy_providers/linux-bkm.yaml
+    interval: 3600
+    health-check:
+      enable: true
+      url: "https://www.gstatic.com/generate_204"
+      interval: 900
+      timeout: 5000
+      lazy: true
+      expected-status: 204
+
+  vless:
+    type: http
+    url: "https://replace.invalid/vless-subscription"
+    path: ./proxy_providers/vless.yaml
+    interval: 3600
+    health-check:
+      enable: true
+      url: "https://www.gstatic.com/generate_204"
+      interval: 900
+      timeout: 5000
+      lazy: true
+      expected-status: 204
+
+  linux-share:
+    type: http
+    url: "https://replace.invalid/linux-share-subscription"
+    path: ./proxy_providers/linux-share.yaml
+    interval: 3600
+    health-check:
+      enable: true
+      url: "https://www.gstatic.com/generate_204"
+      interval: 900
+      timeout: 5000
+      lazy: true
+      expected-status: 204
+
+# ----------------- 锚点与模板 (Templates & Anchors) -----------------
+templates:
+  - &url_test_template
+    type: url-test
+    include-all: true
+    # Helen 节点保留在“手动选择”中，但不参加自动测速，避免不稳定节点被自动选中。
+    exclude-filter: '(?i)helen'
+    url: 'https://www.gstatic.com/generate_204'
+    interval: 900
+    tolerance: 100
+    lazy: true
+    max-failed-times: 3
+
+  - &GlobalProxies
+    type: select
+    proxies: [♻️ 自动选择, 🚀 节点选择]
+  - &USProxies
+    type: select
+    proxies: [🏚️ 家宽节点, 🇺🇲 美国节点, ♻️ 自动选择, 🚀 节点选择]
+  - &DirectFirst
+    type: select
+    proxies: [DIRECT, 🚀 节点选择]
+  - &AIProxies
+    type: select
+    proxies: [🏚️ 家宽节点, 🇺🇲 美国节点, 🇯🇵 日本节点, 🇸🇬 新加坡节点, 🇹🇼 台湾节点, ♻️ 自动选择]
+  - &OfficeProxies
+    type: select
+    proxies: [🏚️ 家宽节点, 🇺🇲 美国节点, 🇯🇵 日本节点, 🇸🇬 新加坡节点, 🇹🇼 台湾节点, ♻️ 自动选择, 🚀 节点选择]
+  - &YouTubeProxies
+    type: select
+    proxies: [♻️ 自动选择, 🇺🇲 美国节点, 🇸🇬 新加坡节点, 🇯🇵 日本节点, 🇹🇼 台湾节点, 🏚️ 家宽节点, 🚀 节点选择]
+  - &SpeedtestProxies
+    type: select
+    proxies: [DIRECT, ♻️ 自动选择, 🚀 节点选择]
+
+# ----------------- 策略组 (Proxy Groups) -----------------
+proxy-groups:
+  - name: 🚀 节点选择
+    type: select
+    proxies: [手动选择, 🏚️ 家宽节点, ♻️ 自动选择, 🇭🇰 香港节点, 🇺🇲 美国节点, 🇯🇵 日本节点, 🇹🇼 台湾节点, 🇸🇬 新加坡节点, 🌍 其他节点]
+
+  - name: 手动选择
+    type: select
+    include-all: true
+
+  - name: 📹 YouTube
+    <<: *YouTubeProxies
+  - name: 🍀 Google
+    <<: *AIProxies
+  - name: 🍒 microsoft
+    <<: *OfficeProxies
+  - name: 🏹 ChatGPT
+    <<: *AIProxies
+  - name: 💻 GitHub
+    <<: *OfficeProxies
+  - name: 🐬 外贸
+    <<: *USProxies
+  - name: 🎵 TikTok
+    <<: *GlobalProxies
+  - name: 📲 Telegram
+    <<: *GlobalProxies
+  - name: 🎥 NETFLIX
+    <<: *GlobalProxies
+  - name: ✈️ Speedtest
+    <<: *SpeedtestProxies
+  - name: 💶 PayPal
+    <<: *GlobalProxies
+  - name: ☁️ cloudflare
+    <<: *GlobalProxies
+  - name: 🍎 Apple
+    <<: *DirectFirst
+  - name: 🎯 全球直连
+    <<: *DirectFirst
+  - name: 🐟 漏网之鱼
+    <<: *GlobalProxies
+  - name: 🛑 广告拦截
+    type: select
+    proxies: [REJECT]
+
+  - name: 🇭🇰 香港节点
+    <<: *url_test_template
+    filter: '^(?=.*(?i)(?:香港|港|🇭🇰|HK|Hong Kong|HKG|沪港|深港|Kowloon|Victoria))(?!.*(?i)(?:美|🇺🇸|US|台|🇹🇼|TW|日|🇯🇵|JP|新|🇸🇬|SG|韩|🇰🇷|KR|专线|到期|过期|剩余|流量|时间|官网|产品|倍率\s*(?:[6-9]|[1-9]\d)(?:\.\d+)?|(?:[6-9]|[1-9]\d)(?:\.\d+)?\s*(?:x|×|倍))).*$'
+
+  - name: 🇺🇲 美国节点
+    <<: *url_test_template
+    filter: '^(?=.*(?i)(?:美|🇺🇸|US|USA|States|American|波特兰|达拉斯|俄勒冈|凤凰城|费利蒙|硅谷|拉斯维加斯|洛杉矶|圣何塞|圣克拉拉|西雅图|芝加哥|纽约|New York|Miami|Boston|United States|San Francisco))(?!.*(?i)(?:港|🇭🇰|HK|台|🇹🇼|TW|日|🇯🇵|JP|新|🇸🇬|SG|韩|🇰🇷|KR|专线|到期|过期|剩余|流量|时间|官网|产品|倍率\s*(?:[6-9]|[1-9]\d)(?:\.\d+)?|(?:[6-9]|[1-9]\d)(?:\.\d+)?\s*(?:x|×|倍))).*$'
+
+  - name: 🇯🇵 日本节点
+    <<: *url_test_template
+    filter: '^(?=.*(?i)(?:日本|🇯🇵|JP|NRT|KIX|FUK|Japan|川日|东京|大阪|泉日|埼玉|名古屋|Nagoya|Kyoto|Okinawa))(?!.*(?i)(?:美|🇺🇸|US|港|🇭🇰|HK|台|🇹🇼|TW|新|🇸🇬|SG|韩|🇰🇷|KR|专线|到期|过期|剩余|流量|时间|官网|产品|倍率\s*(?:[6-9]|[1-9]\d)(?:\.\d+)?|(?:[6-9]|[1-9]\d)(?:\.\d+)?\s*(?:x|×|倍))).*$'
+
+  - name: 🇹🇼 台湾节点
+    <<: *url_test_template
+    filter: '^(?=.*(?i)(?:台湾|台|🇹🇼|TW|TPE|KHH|Taiwan|新北|彰化|台北|Taipei|高雄|Kaohsiung|Taichung|台中))(?!.*(?i)(?:美|🇺🇸|US|港|🇭🇰|HK|日|🇯🇵|JP|新|🇸🇬|SG|韩|🇰🇷|KR|专线|到期|过期|剩余|流量|时间|官网|产品|倍率\s*(?:[6-9]|[1-9]\d)(?:\.\d+)?|(?:[6-9]|[1-9]\d)(?:\.\d+)?\s*(?:x|×|倍))).*$'
+
+  - name: 🇸🇬 新加坡节点
+    <<: *url_test_template
+    filter: '^(?=.*(?i)(?:新加坡|坡|狮城|🇸🇬|SG|SIN|Singapore|Changi|Marina Bay))(?!.*(?i)(?:美|🇺🇸|US|港|🇭🇰|HK|台|🇹🇼|TW|日|🇯🇵|JP|韩|🇰🇷|KR|专线|到期|过期|剩余|流量|时间|官网|产品|倍率\s*(?:[6-9]|[1-9]\d)(?:\.\d+)?|(?:[6-9]|[1-9]\d)(?:\.\d+)?\s*(?:x|×|倍))).*$'
+
+  - name: 🌍 其他节点
+    <<: *url_test_template
+    filter: '^(?!.*(?i)(?:美|🇺🇸|US|日本|🇯🇵|JP|台湾|🇹🇼|TW|新加坡|🇸🇬|SG|香港|🇭🇰|HK|韩|🇰🇷|KR|专线|到期|过期|剩余|流量|时间|官网|产品|倍率\s*(?:[6-9]|[1-9]\d)(?:\.\d+)?|(?:[6-9]|[1-9]\d)(?:\.\d+)?\s*(?:x|×|倍))).*$'
+
+  - name: 🏚️ 家宽节点
+    <<: *url_test_template
+    filter: '^(?=.*(?i)(?:家宽))(?=.*(?i)(?:美国|🇺🇸|(?:^|[^A-Za-z])(?:US|USA)(?:[^A-Za-z]|$)|United States|American|波特兰|达拉斯|俄勒冈|凤凰城|费利蒙|硅谷|拉斯维加斯|洛杉矶|圣何塞|圣克拉拉|西雅图|芝加哥|纽约|New York|Miami|Boston|San Francisco))(?!.*(?i)(?:亚洲|专线|到期|过期|剩余|流量|时间|官网|产品|倍率\s*(?:[6-9]|[1-9]\d)(?:\.\d+)?|(?:[6-9]|[1-9]\d)(?:\.\d+)?\s*(?:x|×|倍))).*$'
+
+  - name: ♻️ 自动选择
+    type: url-test
+    proxies: [🇭🇰 香港节点, 🇺🇲 美国节点, 🇯🇵 日本节点, 🇹🇼 台湾节点, 🇸🇬 新加坡节点, 🌍 其他节点]
+    url: 'https://www.gstatic.com/generate_204'
+    interval: 900
+    tolerance: 100
+    lazy: true
+    max-failed-times: 3
+
+# ----------------- 规则 (Rules) -----------------
+rules:
+  - DOMAIN-SUFFIX,linux.do,♻️ 自动选择
+  - RULE-SET,private_domain,DIRECT
+  - RULE-SET,my_direct,DIRECT
+  - RULE-SET,apple_domain,🍎 Apple
+  - RULE-SET,my_proxylite,🚀 节点选择
+  - RULE-SET,my_ai_exe,🏹 ChatGPT
+  - RULE-SET,my_ai,🏹 ChatGPT
+  - RULE-SET,my_wm,🐬 外贸
+  - RULE-SET,openai_domain,🏹 ChatGPT
+  - RULE-SET,ai_domain,🏹 ChatGPT
+  - RULE-SET,github_domain,💻 GitHub
+  - RULE-SET,youtube_domain,📹 YouTube
+  - RULE-SET,facebook_domain,🐬 外贸
+  - RULE-SET,whatsapp_domain,🐬 外贸
+  - RULE-SET,instagram_domain,🐬 外贸
+  - RULE-SET,linkedin_domain,🐬 外贸
+  - RULE-SET,x_domain,🐬 外贸
+  - RULE-SET,google_domain,🍀 Google
+  - RULE-SET,google_gemini_domain,🍀 Google
+  - RULE-SET,onedrive_domain,🍒 microsoft
+  - RULE-SET,microsoft_domain,🍒 microsoft
+  - RULE-SET,cloudflare_domain,☁️ cloudflare
+  - RULE-SET,tiktok_domain,🎵 TikTok
+  - RULE-SET,speedtest_domain,✈️ Speedtest
+  - RULE-SET,telegram_domain,📲 Telegram
+  - RULE-SET,netflix_domain,🎥 NETFLIX
+  - RULE-SET,paypal_domain,💶 PayPal
+  - IP-CIDR,8.8.8.8/32,🍀 Google,no-resolve
+  - IP-CIDR,8.8.4.4/32,🍀 Google,no-resolve
+  - IP-CIDR,1.1.1.1/32,☁️ cloudflare,no-resolve
+  - IP-CIDR,1.0.0.1/32,☁️ cloudflare,no-resolve
+  - RULE-SET,cn_domain,🎯 全球直连
+  - RULE-SET,geolocation-!cn,🚀 节点选择
+  - RULE-SET,google_ip,🍀 Google,no-resolve
+  - RULE-SET,facebook_ip,🐬 外贸,no-resolve
+  - RULE-SET,netflix_ip,🎥 NETFLIX,no-resolve
+  - RULE-SET,telegram_ip,📲 Telegram,no-resolve
+  - RULE-SET,cloudflare_ip,☁️ cloudflare,no-resolve
+  - RULE-SET,cn_ip,🎯 全球直连
+  - MATCH,🐟 漏网之鱼
+
+rule-anchor:
+  ip: &ip {type: http, interval: 86400, behavior: ipcidr, format: mrs}
+  domain: &domain {type: http, interval: 86400, behavior: domain, format: mrs}
+  class: &class {type: http, interval: 86400, behavior: classical, format: text}
+
+rule-providers:
+  youtube_domain: {!!merge <<: *domain, url: "https://raw.githubusercontent.com/MetaCubeX/meta-rules-dat/meta/geo/geosite/youtube.mrs"}
+  private_domain: {!!merge <<: *domain, url: "https://raw.githubusercontent.com/MetaCubeX/meta-rules-dat/meta/geo/geosite/private.mrs"}
+  my_proxylite: {!!merge <<: *class, url: "https://raw.githubusercontent.com/hiven425/hiven/refs/heads/master/config/ProxyLite.list"}
+  my_ai: {!!merge <<: *class, url: "https://raw.githubusercontent.com/hiven425/hiven/refs/heads/master/config/AI.list"}
+  my_ai_exe: {!!merge <<: *class, url: "https://raw.githubusercontent.com/hiven425/hiven/refs/heads/master/config/ai-exe.list"}
+  my_direct: {!!merge <<: *class, url: "https://raw.githubusercontent.com/hiven425/hiven/refs/heads/master/config/Direct.list"}
+  my_wm: {!!merge <<: *class, url: "https://raw.githubusercontent.com/hiven425/hiven/refs/heads/master/config/wm.list"}
+  ai_domain: {!!merge <<: *domain, url: "https://github.com/DustinWin/ruleset_geodata/releases/download/mihomo-ruleset/ai.mrs"}
+  openai_domain: {!!merge <<: *domain, url: "https://raw.githubusercontent.com/MetaCubeX/meta-rules-dat/meta/geo/geosite/openai.mrs"}
+  google_domain: {!!merge <<: *domain, url: "https://raw.githubusercontent.com/MetaCubeX/meta-rules-dat/meta/geo/geosite/google.mrs"}
+  google_gemini_domain: {!!merge <<: *domain, url: "https://raw.githubusercontent.com/MetaCubeX/meta-rules-dat/meta/geo/geosite/google-gemini.mrs"}
+  github_domain: {!!merge <<: *domain, url: "https://raw.githubusercontent.com/MetaCubeX/meta-rules-dat/meta/geo/geosite/github.mrs"}
+  telegram_domain: {!!merge <<: *domain, url: "https://raw.githubusercontent.com/MetaCubeX/meta-rules-dat/meta/geo/geosite/telegram.mrs"}
+  netflix_domain: {!!merge <<: *domain, url: "https://raw.githubusercontent.com/MetaCubeX/meta-rules-dat/meta/geo/geosite/netflix.mrs"}
+  paypal_domain: {!!merge <<: *domain, url: "https://raw.githubusercontent.com/MetaCubeX/meta-rules-dat/meta/geo/geosite/paypal.mrs"}
+  onedrive_domain: {!!merge <<: *domain, url: "https://raw.githubusercontent.com/MetaCubeX/meta-rules-dat/meta/geo/geosite/onedrive.mrs"}
+  microsoft_domain: {!!merge <<: *domain, url: "https://raw.githubusercontent.com/MetaCubeX/meta-rules-dat/meta/geo/geosite/microsoft.mrs"}
+  apple_domain: {!!merge <<: *domain, url: "https://raw.githubusercontent.com/MetaCubeX/meta-rules-dat/meta/geo/geosite/apple-cn.mrs"}
+  speedtest_domain: {!!merge <<: *domain, url: "https://raw.githubusercontent.com/MetaCubeX/meta-rules-dat/meta/geo/geosite/ookla-speedtest.mrs"}
+  tiktok_domain: {!!merge <<: *domain, url: "https://raw.githubusercontent.com/MetaCubeX/meta-rules-dat/meta/geo/geosite/tiktok.mrs"}
+  gfw_domain: {!!merge <<: *domain, url: "https://raw.githubusercontent.com/MetaCubeX/meta-rules-dat/meta/geo/geosite/gfw.mrs"}
+  geolocation-!cn: {!!merge <<: *domain, url: "https://raw.githubusercontent.com/MetaCubeX/meta-rules-dat/meta/geo/geosite/geolocation-!cn.mrs"}
+  cn_domain: {!!merge <<: *domain, url: "https://raw.githubusercontent.com/MetaCubeX/meta-rules-dat/meta/geo/geosite/cn.mrs"}
+  facebook_domain: {!!merge <<: *domain, url: "https://raw.githubusercontent.com/MetaCubeX/meta-rules-dat/meta/geo/geosite/facebook.mrs"}
+  whatsapp_domain: {!!merge <<: *domain, url: "https://raw.githubusercontent.com/MetaCubeX/meta-rules-dat/meta/geo/geosite/whatsapp.mrs"}
+  instagram_domain: {!!merge <<: *domain, url: "https://raw.githubusercontent.com/MetaCubeX/meta-rules-dat/meta/geo/geosite/instagram.mrs"}
+  linkedin_domain: {!!merge <<: *domain, url: "https://raw.githubusercontent.com/MetaCubeX/meta-rules-dat/meta/geo/geosite/linkedin.mrs"}
+  x_domain: {!!merge <<: *domain, url: "https://raw.githubusercontent.com/MetaCubeX/meta-rules-dat/meta/geo/geosite/x.mrs"}
+  cloudflare_domain: {!!merge <<: *domain, url: "https://raw.githubusercontent.com/MetaCubeX/meta-rules-dat/meta/geo/geosite/cloudflare.mrs"}
+  cn_ip: {!!merge <<: *ip, url: "https://raw.githubusercontent.com/MetaCubeX/meta-rules-dat/meta/geo/geoip/cn.mrs"}
+  google_ip: {!!merge <<: *ip, url: "https://raw.githubusercontent.com/MetaCubeX/meta-rules-dat/meta/geo/geoip/google.mrs"}
+  telegram_ip: {!!merge <<: *ip, url: "https://raw.githubusercontent.com/MetaCubeX/meta-rules-dat/meta/geo/geoip/telegram.mrs"}
+  netflix_ip: {!!merge <<: *ip, url: "https://raw.githubusercontent.com/MetaCubeX/meta-rules-dat/meta/geo/geoip/netflix.mrs"}
+  facebook_ip: {!!merge <<: *ip, url: "https://raw.githubusercontent.com/MetaCubeX/meta-rules-dat/meta/geo/geoip/facebook.mrs"}
+  cloudflare_ip: {!!merge <<: *ip, url: "https://raw.githubusercontent.com/MetaCubeX/meta-rules-dat/meta/geo/geoip/cloudflare.mrs"}

--- a/clash/mihomo.docker.yaml
+++ b/clash/mihomo.docker.yaml
@@ -158,8 +158,6 @@ templates:
   - &url_test_template
     type: url-test
     include-all: true
-    # Helen 节点保留在“手动选择”中，但不参加自动测速，避免不稳定节点被自动选中。
-    exclude-filter: '(?i)helen'
     url: 'https://www.gstatic.com/generate_204'
     interval: 900
     tolerance: 100
@@ -204,6 +202,9 @@ proxy-groups:
     <<: *AIProxies
   - name: 🍒 microsoft
     <<: *OfficeProxies
+  - name: 📦 微软大流量
+    type: select
+    proxies: [DIRECT, 🚀 节点选择]
   - name: 🏹 ChatGPT
     <<: *AIProxies
   - name: 💻 GitHub
@@ -272,6 +273,10 @@ proxy-groups:
 # ----------------- 规则 (Rules) -----------------
 rules:
   - DOMAIN-SUFFIX,linux.do,♻️ 自动选择
+  # Microsoft 大流量下载必须先于控制面和通用 Microsoft 规则匹配。
+  - RULE-SET,microsoft_download,📦 微软大流量
+  - RULE-SET,microsoft_direct,DIRECT
+  - RULE-SET,microsoft_proxy,🍒 microsoft
   - RULE-SET,private_domain,DIRECT
   - RULE-SET,my_direct,DIRECT
   - RULE-SET,apple_domain,🍎 Apple
@@ -325,6 +330,9 @@ rule-providers:
   my_ai_exe: {!!merge <<: *class, url: "https://raw.githubusercontent.com/hiven425/hiven/refs/heads/master/config/ai-exe.list"}
   my_direct: {!!merge <<: *class, url: "https://raw.githubusercontent.com/hiven425/hiven/refs/heads/master/config/Direct.list"}
   my_wm: {!!merge <<: *class, url: "https://raw.githubusercontent.com/hiven425/hiven/refs/heads/master/config/wm.list"}
+  microsoft_download: {!!merge <<: *class, url: "https://raw.githubusercontent.com/hiven425/hiven/refs/heads/master/config/MicrosoftDownload.list"}
+  microsoft_direct: {!!merge <<: *class, url: "https://raw.githubusercontent.com/hiven425/hiven/refs/heads/master/config/MicrosoftDirect.list"}
+  microsoft_proxy: {!!merge <<: *class, url: "https://raw.githubusercontent.com/hiven425/hiven/refs/heads/master/config/MicrosoftProxy.list"}
   ai_domain: {!!merge <<: *domain, url: "https://github.com/DustinWin/ruleset_geodata/releases/download/mihomo-ruleset/ai.mrs"}
   openai_domain: {!!merge <<: *domain, url: "https://raw.githubusercontent.com/MetaCubeX/meta-rules-dat/meta/geo/geosite/openai.mrs"}
   google_domain: {!!merge <<: *domain, url: "https://raw.githubusercontent.com/MetaCubeX/meta-rules-dat/meta/geo/geosite/google.mrs"}

--- a/clash/mihomo.sparkle.yaml
+++ b/clash/mihomo.sparkle.yaml
@@ -163,6 +163,9 @@ proxy-groups:
     <<: *AIProxies
   - name: 🍒 microsoft
     <<: *OfficeProxies
+  - name: 📦 微软大流量
+    type: select
+    proxies: [DIRECT, 🚀 节点选择]
   - name: 🏹 ChatGPT
     <<: *AIProxies
   - name: 💻 GitHub
@@ -231,6 +234,10 @@ proxy-groups:
 rules:
   - PROCESS-NAME,Speedtest.exe,✈️ Speedtest
   - DOMAIN-SUFFIX,linux.do,♻️ 自动选择
+  # Microsoft 大流量下载必须先于控制面和通用 Microsoft 规则匹配。
+  - RULE-SET,microsoft_download,📦 微软大流量
+  - RULE-SET,microsoft_direct,DIRECT
+  - RULE-SET,microsoft_proxy,🍒 microsoft
   - RULE-SET,private_domain,DIRECT
   - RULE-SET,my_direct,DIRECT
   - RULE-SET,apple_domain,🍎 Apple
@@ -284,6 +291,9 @@ rule-providers:
   my_ai_exe: {!!merge <<: *class, url: "https://raw.githubusercontent.com/hiven425/hiven/refs/heads/master/config/ai-exe.list"}
   my_direct: {!!merge <<: *class, url: "https://raw.githubusercontent.com/hiven425/hiven/refs/heads/master/config/Direct.list"}
   my_wm: {!!merge <<: *class, url: "https://raw.githubusercontent.com/hiven425/hiven/refs/heads/master/config/wm.list"}
+  microsoft_download: {!!merge <<: *class, url: "https://raw.githubusercontent.com/hiven425/hiven/refs/heads/master/config/MicrosoftDownload.list"}
+  microsoft_direct: {!!merge <<: *class, url: "https://raw.githubusercontent.com/hiven425/hiven/refs/heads/master/config/MicrosoftDirect.list"}
+  microsoft_proxy: {!!merge <<: *class, url: "https://raw.githubusercontent.com/hiven425/hiven/refs/heads/master/config/MicrosoftProxy.list"}
   ai_domain: {!!merge <<: *domain, url: "https://github.com/DustinWin/ruleset_geodata/releases/download/mihomo-ruleset/ai.mrs"}
   openai_domain: {!!merge <<: *domain, url: "https://raw.githubusercontent.com/MetaCubeX/meta-rules-dat/meta/geo/geosite/openai.mrs"}
   google_domain: {!!merge <<: *domain, url: "https://raw.githubusercontent.com/MetaCubeX/meta-rules-dat/meta/geo/geosite/google.mrs"}

--- a/config/MicrosoftDirect.list
+++ b/config/MicrosoftDirect.list
@@ -1,0 +1,12 @@
+# Microsoft Store 页面、目录、认证、授权和 Delivery Optimization 调度
+DOMAIN,storeedge.microsoft.com
+DOMAIN-SUFFIX,storeedgefd.dsx.mp.microsoft.com
+DOMAIN-SUFFIX,displaycatalog.mp.microsoft.com
+DOMAIN-SUFFIX,displaycatalog.md.mp.microsoft.com
+DOMAIN-SUFFIX,licensing.mp.microsoft.com
+DOMAIN-SUFFIX,licensing.md.mp.microsoft.com
+DOMAIN-SUFFIX,purchase.mp.microsoft.com
+DOMAIN-SUFFIX,purchase.md.mp.microsoft.com
+DOMAIN,login.live.com
+DOMAIN,tsfe.trafficshaping.dsp.mp.microsoft.com
+DOMAIN-SUFFIX,prod.do.dsp.mp.microsoft.com

--- a/config/MicrosoftDownload.list
+++ b/config/MicrosoftDownload.list
@@ -1,0 +1,3 @@
+# Microsoft Store / Windows Update 大流量内容下载
+DOMAIN-SUFFIX,dl.delivery.mp.microsoft.com
+DOMAIN-SUFFIX,windowsupdate.com

--- a/config/MicrosoftProxy.list
+++ b/config/MicrosoftProxy.list
@@ -1,0 +1,6 @@
+# Windows Update 检测、元数据和更新服务控制面
+DOMAIN,fe2.update.microsoft.com
+DOMAIN,sls.update.microsoft.com
+DOMAIN-SUFFIX,api.cdp.microsoft.com
+DOMAIN-SUFFIX,update.microsoft.com
+DOMAIN-SUFFIX,delivery.mp.microsoft.com


### PR DESCRIPTION
## What changed

- Add `clash/mihomo.docker.yaml` as a public WSL2/Docker-oriented Mihomo template.
- Keep all subscription providers, including Helen, eligible for automatic latency selection.
- Split Microsoft traffic into download, direct service, and proxied control-plane rule sets.
- Apply the Microsoft routing consistently to `mihomo.sparkle.yaml` and `mihomo.docker.yaml`.
- Cover Microsoft Store catalog, licensing, purchase, CDN, Windows Update, and Delivery Optimization endpoints without committing private subscription URLs or controller secrets.

## Why

The desktop configuration binds services to container-local loopback and enables TUN/process inspection, which does not fit the current unprivileged Docker deployment. Microsoft download payloads are also large and benefit from a direct-first policy, while update control-plane endpoints can retain the existing Microsoft proxy strategy. The ordering ensures payload domains such as `dl.delivery.mp.microsoft.com` are matched before the broader `delivery.mp.microsoft.com` proxy rule.

Endpoint coverage was checked against Microsoft documentation:

- https://learn.microsoft.com/windows/deployment/do/delivery-optimization-endpoints
- https://learn.microsoft.com/windows/privacy/manage-windows-11-endpoints
- https://learn.microsoft.com/intune/intune-service/fundamentals/intune-endpoints

## Impact

- Sibling containers can use Mihomo at `http://mihomo:7890`.
- Helen nodes remain available to both manual and automatic groups.
- Windows Update and Microsoft Store payload downloads default to direct traffic but remain selectable through `📦 微软大流量`.
- Private provider URLs and the controller secret must still be filled only in the deployed local copy.

## Validation

- `git diff --check`
- Both YAML files pass `metacubex/mihomo:latest -t`.
- All three local Microsoft rule-provider files load successfully through Mihomo.
- Rule format, duplicates, and representative first-match routing cases were checked.